### PR TITLE
Observe changes to isLowPowerMode and cache the values as they change…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# 1.7.0 / 09-27-2021
+
+### Changes
+
+* [BUGFIX] RUM: Fix `DDRUMView` API visibility for Objective-C. See [#583][]
+* [FEATURE] Crash Reporting: Add `DatadogCrashReporting`
+* [FEATURE] RUM: Add Mobile Vitals. See [#493][] [#514][] [#522][] [#495][]
+* [FEATURE] RUM: Add option for renaming instrumented actions. See [#539][]
+* [FEATURE] RUM: Add option for tracking events when app is in background. See [#504][] [#537][]
+* [FEATURE] Add support for `us3` site. See [#523][]
+* [IMPROVEMENT] RUM: Improve RUM <> APM integration. See [#524][] [#575][] [#531][] (Thanks [@jracollins][], [@marcusway][])
+* [IMPROVEMENT] RUM: Improve naming for views started with `key:`. See [#534][]
+* [IMPROVEMENT] RUM: Improve actions instrumentation. See [#509][] [#545][] [#547][]
+* [IMPROVEMENT] RUM: Sanitize custom timings for views. See [#525][]
+* [IMPROVEMENT] Do not retry uploading events if Client Token is invalid. See [#535][]
+
 # 1.6.0 / 06-09-2021
 
 ### Changes
@@ -200,6 +216,24 @@
 [#479]: https://github.com/DataDog/dd-sdk-ios/issues/479
 [#481]: https://github.com/DataDog/dd-sdk-ios/issues/481
 [#483]: https://github.com/DataDog/dd-sdk-ios/issues/483
+[#493]: https://github.com/DataDog/dd-sdk-ios/issues/493
+[#495]: https://github.com/DataDog/dd-sdk-ios/issues/495
+[#504]: https://github.com/DataDog/dd-sdk-ios/issues/504
+[#509]: https://github.com/DataDog/dd-sdk-ios/issues/509
+[#514]: https://github.com/DataDog/dd-sdk-ios/issues/514
+[#522]: https://github.com/DataDog/dd-sdk-ios/issues/522
+[#523]: https://github.com/DataDog/dd-sdk-ios/issues/523
+[#524]: https://github.com/DataDog/dd-sdk-ios/issues/524
+[#525]: https://github.com/DataDog/dd-sdk-ios/issues/525
+[#531]: https://github.com/DataDog/dd-sdk-ios/issues/531
+[#534]: https://github.com/DataDog/dd-sdk-ios/issues/534
+[#535]: https://github.com/DataDog/dd-sdk-ios/issues/535
+[#537]: https://github.com/DataDog/dd-sdk-ios/issues/537
+[#539]: https://github.com/DataDog/dd-sdk-ios/issues/539
+[#545]: https://github.com/DataDog/dd-sdk-ios/issues/545
+[#547]: https://github.com/DataDog/dd-sdk-ios/issues/547
+[#575]: https://github.com/DataDog/dd-sdk-ios/issues/575
+[#583]: https://github.com/DataDog/dd-sdk-ios/issues/583
 [@00FA9A]: https://github.com/00FA9A
 [@Britton-Earnin]: https://github.com/Britton-Earnin
 [@Hengyu]: https://github.com/Hengyu
@@ -211,8 +245,10 @@
 [@hyling]: https://github.com/hyling
 [@jegnux]: https://github.com/jegnux
 [@joeydong]: https://github.com/joeydong
+[@jracollins]: https://github.com/jracollins
 [@lgaches]: https://github.com/lgaches
 [@lmramirez]: https://github.com/lmramirez
+[@marcusway]: https://github.com/marcusway
 [@philtre]: https://github.com/philtre
 [@provTheodoreNewell]: https://github.com/provTheodoreNewell
 [@sdejesusF]: https://github.com/sdejesusF

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "lyft/Kronos" ~> 4.2
-github "microsoft/plcrashreporter" == 1.8.1
+github "microsoft/plcrashreporter" == 1.10.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "lyft/Kronos" ~> 4.2
-github "microsoft/plcrashreporter" == 1.10.0
+github "microsoft/plcrashreporter" ~> 1.10.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "lyft/Kronos" "4.2.1"
-github "microsoft/plcrashreporter" "1.8.1"
+github "microsoft/plcrashreporter" "1.10.0"

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -441,6 +441,7 @@
 		61F3CDA72512144600C816E5 /* UIKitRUMViewsPredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F3CDA62512144600C816E5 /* UIKitRUMViewsPredicate.swift */; };
 		61F3CDAB25121FB500C816E5 /* UIViewControllerSwizzlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F3CDAA25121FB500C816E5 /* UIViewControllerSwizzlerTests.swift */; };
 		61F3CDAD25122C9200C816E5 /* UIKitRUMViewsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F3CDAC25122C9200C816E5 /* UIKitRUMViewsHandlerTests.swift */; };
+		61F74AF426F20E4600E5F5ED /* DebugCrashReportingWithRUMViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F74AF326F20E4600E5F5ED /* DebugCrashReportingWithRUMViewController.swift */; };
 		61F7F1DD266F9CB000F9F53B /* CodableValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133BA02423979B00786299 /* CodableValue.swift */; };
 		61F8CC092469295500FE2908 /* DatadogConfigurationBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F8CC082469295500FE2908 /* DatadogConfigurationBuilderTests.swift */; };
 		61F9CA712512450B000A5E61 /* RUMAutoInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F9CA702512450B000A5E61 /* RUMAutoInstrumentationTests.swift */; };
@@ -1073,6 +1074,7 @@
 		61F3CDA62512144600C816E5 /* UIKitRUMViewsPredicate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitRUMViewsPredicate.swift; sourceTree = "<group>"; };
 		61F3CDAA25121FB500C816E5 /* UIViewControllerSwizzlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewControllerSwizzlerTests.swift; sourceTree = "<group>"; };
 		61F3CDAC25122C9200C816E5 /* UIKitRUMViewsHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitRUMViewsHandlerTests.swift; sourceTree = "<group>"; };
+		61F74AF326F20E4600E5F5ED /* DebugCrashReportingWithRUMViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugCrashReportingWithRUMViewController.swift; sourceTree = "<group>"; };
 		61F8CC082469295500FE2908 /* DatadogConfigurationBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogConfigurationBuilderTests.swift; sourceTree = "<group>"; };
 		61F9CA702512450B000A5E61 /* RUMAutoInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMAutoInstrumentationTests.swift; sourceTree = "<group>"; };
 		61F9CA782512593A000A5E61 /* RUMNavigationControllerScenario.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RUMNavigationControllerScenario.storyboard; sourceTree = "<group>"; };
@@ -2171,6 +2173,7 @@
 				61441C942461A649003D8BB8 /* DebugLoggingViewController.swift */,
 				61441C932461A649003D8BB8 /* DebugTracingViewController.swift */,
 				61E5333724B84EE2003D6C4E /* DebugRUMViewController.swift */,
+				61F74AF326F20E4600E5F5ED /* DebugCrashReportingWithRUMViewController.swift */,
 			);
 			path = Debugging;
 			sourceTree = "<group>";
@@ -4081,6 +4084,7 @@
 				61D50C5A2580EFF3006038A3 /* URLSessionScenarios.swift in Sources */,
 				614CADCE250FCA0200B93D2D /* TestScenarios.swift in Sources */,
 				6111542525C992F8007C84C9 /* CrashReportingScenarios.swift in Sources */,
+				61F74AF426F20E4600E5F5ED /* DebugCrashReportingWithRUMViewController.swift in Sources */,
 				61441C972461A649003D8BB8 /* UIViewController+KeyboardControlling.swift in Sources */,
 				61B9ED1C2461E12000C0DCFF /* SendLogsFixtureViewController.swift in Sources */,
 				6111543F25C996A5007C84C9 /* CrashReportingViewController.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -297,6 +297,7 @@
 		61993668265BBEDC009D7EA8 /* E2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61993667265BBEDC009D7EA8 /* E2ETests.swift */; };
 		61993673265BC371009D7EA8 /* Kronos.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9E0542CA25F8EBBE007A3D0B /* Kronos.xcframework */; };
 		61993674265BC371009D7EA8 /* Kronos.xcframework in ⚙️ Embed Framework Dependencies */ = {isa = PBXBuildFile; fileRef = 9E0542CA25F8EBBE007A3D0B /* Kronos.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		619A29F326E64910007D62A3 /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 614ED36B260352DC00C8C519 /* CrashReporter.xcframework */; };
 		619E16D82577C1CB00B2516B /* DataProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619E16D72577C1CB00B2516B /* DataProcessor.swift */; };
 		619E16E92578E73E00B2516B /* DataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619E16E82578E73E00B2516B /* DataMigrator.swift */; };
 		619E16F12578E89700B2516B /* DeleteAllDataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619E16F02578E89700B2516B /* DeleteAllDataMigrator.swift */; };
@@ -1226,6 +1227,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				61B7885D25C180CB002675B5 /* DatadogCrashReporting.framework in Frameworks */,
+				619A29F326E64910007D62A3 /* CrashReporter.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Datadog/Example/AppConfiguration.swift
+++ b/Datadog/Example/AppConfiguration.swift
@@ -6,6 +6,7 @@
 
 import UIKit
 import Datadog
+import DatadogCrashReporting
 
 protocol AppConfiguration {
     /// The tracking consent value applied when initializing the SDK.
@@ -45,9 +46,16 @@ struct ExampleAppConfiguration: AppConfiguration {
             .enableInternalMonitoring(clientToken: Environment.readClientToken())
 #endif
 
-        // If the app was launched with test scenarion ENV, apply the scenario configuration
         if let testScenario = testScenario {
+            // If the `Example` app was launched with test scenario ENV, apply the scenario configuration
             testScenario.configureSDK(builder: configuration)
+        } else {
+            // Otherwise just enable all features so they can be tested with debug menu
+            _ = configuration
+                .enableLogging(true)
+                .enableTracing(true)
+                .enableRUM(true)
+                .enableCrashReporting(using: DDCrashReportingPlugin())
         }
 
         return configuration.build()

--- a/Datadog/Example/Base.lproj/Main.storyboard
+++ b/Datadog/Example/Base.lproj/Main.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="gra-d4-cht">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="gra-d4-cht">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -15,17 +16,17 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="1iU-Pd-DNJ">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <view key="tableFooterView" contentMode="scaleToFill" id="wle-IX-rUl">
-                            <rect key="frame" x="0.0" y="186.5" width="414" height="0.0"/>
+                            <rect key="frame" x="0.0" y="223.00000034679067" width="414" height="0.0"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         </view>
                         <sections>
                             <tableViewSection headerTitle="Debug features:" id="tgY-ka-MYv">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="xoO-Hn-N29" style="IBUITableViewCellStyleDefault" id="2Id-yJ-iEw">
-                                        <rect key="frame" x="0.0" y="28" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="24.5" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="2Id-yJ-iEw" id="wdg-my-MT5">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -45,7 +46,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="NMa-2j-8ux" style="IBUITableViewCellStyleDefault" id="xsC-bs-aKd">
-                                        <rect key="frame" x="0.0" y="71.5" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="68" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="xsC-bs-aKd" id="M0h-rT-0mQ">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -65,7 +66,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="yCu-pq-IYL" style="IBUITableViewCellStyleDefault" id="3G8-Wa-fSQ">
-                                        <rect key="frame" x="0.0" y="115" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="111.5" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="3G8-Wa-fSQ" id="7IJ-XI-RAR">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -82,6 +83,26 @@
                                         </tableViewCellContentView>
                                         <connections>
                                             <segue destination="CBf-fg-exz" kind="show" id="5Im-MK-mpd"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="rh1-Lx-HwO" style="IBUITableViewCellStyleDefault" id="cuG-eI-g1N">
+                                        <rect key="frame" x="0.0" y="155" width="414" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="cuG-eI-g1N" id="GVN-Oe-gtW">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Crash Reporting with RUM" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="rh1-Lx-HwO">
+                                                    <rect key="frame" x="20" y="0.0" width="374" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="dzc-N5-XBR" kind="show" id="1x4-GE-iJO"/>
                                         </connections>
                                     </tableViewCell>
                                 </cells>
@@ -129,21 +150,21 @@
                                         <rect key="frame" x="0.0" y="0.0" width="384" height="20"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" text="SERVICE:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vne-5f-T8F">
-                                                <rect key="frame" x="0.0" y="0.0" width="53.5" height="20"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="49.5" height="20"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
-                                                <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <color key="textColor" systemColor="systemGrayColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ez2-PC-S6a">
-                                                <rect key="frame" x="53.5" y="0.0" width="10" height="20"/>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <rect key="frame" x="49.5" y="0.0" width="10" height="20"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="10" id="0sJ-wp-PYC"/>
                                                 </constraints>
                                             </view>
                                             <textField opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="ios-sdk-example-app" borderStyle="roundedRect" placeholder="Enter service name..." textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="fGc-5E-uEZ">
-                                                <rect key="frame" x="63.5" y="0.0" width="320.5" height="20"/>
-                                                <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <rect key="frame" x="59.5" y="0.0" width="324.5" height="20"/>
+                                                <color key="textColor" systemColor="secondaryLabelColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
@@ -154,39 +175,39 @@
                                     </stackView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3rA-Dh-QOm" userLabel="Vertical gap 15">
                                         <rect key="frame" x="0.0" y="20" width="384" height="15"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="15" id="ims-n9-2bf"/>
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Single log" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CV1-qa-sOB">
-                                        <rect key="frame" x="0.0" y="35" width="384" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="35" width="384" height="17"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iFn-el-aip" userLabel="Vertical gap 10">
-                                        <rect key="frame" x="0.0" y="55.5" width="384" height="10"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <rect key="frame" x="0.0" y="52" width="384" height="10"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="DbU-pK-4j7"/>
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="LEVEL:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dR9-IX-p5V">
-                                        <rect key="frame" x="0.0" y="65.5" width="384" height="14.5"/>
+                                        <rect key="frame" x="0.0" y="62" width="384" height="13.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
-                                        <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="textColor" systemColor="systemGrayColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kqj-rM-OTV" userLabel="Vertical gap 5">
-                                        <rect key="frame" x="0.0" y="80" width="384" height="5"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <rect key="frame" x="0.0" y="75.5" width="384" height="5"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="5" id="xfF-Yw-izI"/>
                                         </constraints>
                                     </view>
                                     <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="UdV-tc-uuY">
-                                        <rect key="frame" x="0.0" y="85" width="384" height="45"/>
+                                        <rect key="frame" x="0.0" y="80.5" width="384" height="45"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="oPQ-Ng-44a"/>
                                         </constraints>
@@ -200,27 +221,27 @@
                                         </segments>
                                     </segmentedControl>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="P9X-Q2-9qd" userLabel="Vertical gap 10">
-                                        <rect key="frame" x="0.0" y="129" width="384" height="10"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <rect key="frame" x="0.0" y="124.5" width="384" height="10"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="A24-Bm-eBl"/>
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MESSAGE:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mAn-oB-k6U">
-                                        <rect key="frame" x="0.0" y="139" width="384" height="14.5"/>
+                                        <rect key="frame" x="0.0" y="134.5" width="384" height="13.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
-                                        <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="textColor" systemColor="systemGrayColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ayK-SK-Oab" userLabel="Vertical gap 5">
-                                        <rect key="frame" x="0.0" y="153.5" width="384" height="5"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <rect key="frame" x="0.0" y="148" width="384" height="5"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="5" id="2n3-c0-HAm"/>
                                         </constraints>
                                     </view>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Enter log message..." textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="jxw-Tx-HjK">
-                                        <rect key="frame" x="0.0" y="158.5" width="384" height="44"/>
+                                        <rect key="frame" x="0.0" y="153" width="384" height="44"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="45u-SB-xBU"/>
                                         </constraints>
@@ -228,14 +249,14 @@
                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="continue" enablesReturnKeyAutomatically="YES" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
                                     </textField>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="I51-hP-D8P" userLabel="Vertical gap 10">
-                                        <rect key="frame" x="0.0" y="202.5" width="384" height="10"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <rect key="frame" x="0.0" y="197" width="384" height="10"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="8vL-62-VnN"/>
                                         </constraints>
                                     </view>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="PLk-ao-bzx">
-                                        <rect key="frame" x="0.0" y="212.5" width="384" height="44"/>
+                                        <rect key="frame" x="0.0" y="207" width="384" height="44"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gtC-h0-4xC">
                                                 <rect key="frame" x="0.0" y="0.0" width="189.5" height="44"/>
@@ -280,43 +301,43 @@
                                         </constraints>
                                     </stackView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Rlt-GG-uem" userLabel="Vertical gap 10">
-                                        <rect key="frame" x="0.0" y="256.5" width="384" height="10"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <rect key="frame" x="0.0" y="251" width="384" height="10"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="oUy-Tr-5NI"/>
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CONSOLE OUTPUT:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="x1i-in-lYX">
-                                        <rect key="frame" x="0.0" y="266.5" width="384" height="14.5"/>
+                                        <rect key="frame" x="0.0" y="261" width="384" height="13.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
-                                        <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="textColor" systemColor="systemGrayColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MU9-DG-sTJ" userLabel="Vertical gap 10">
-                                        <rect key="frame" x="0.0" y="281" width="384" height="10"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <rect key="frame" x="0.0" y="274.5" width="384" height="10"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="P0L-Pu-XZ9"/>
                                         </constraints>
                                     </view>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2G0-OF-tGX">
-                                        <rect key="frame" x="0.0" y="291" width="384" height="453"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                        <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <rect key="frame" x="0.0" y="284.5" width="384" height="459.5"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <color key="textColor" systemColor="systemGrayColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                     </textView>
                                 </subviews>
                             </stackView>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="8Ej-XI-aBq" secondAttribute="bottom" constant="15" id="3gi-r7-60l"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="8Ej-XI-aBq" secondAttribute="trailing" constant="15" id="5Ic-p0-TAp"/>
                             <constraint firstItem="8Ej-XI-aBq" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="15" id="JUA-HU-bsu"/>
                             <constraint firstItem="8Ej-XI-aBq" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="15" id="NUg-dD-pQw"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                     <navigationItem key="navigationItem" id="7vC-Cy-I7K"/>
                     <connections>
@@ -347,21 +368,21 @@
                                         <rect key="frame" x="0.0" y="0.0" width="384" height="20"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" text="SERVICE:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mow-kt-hfL">
-                                                <rect key="frame" x="0.0" y="0.0" width="53.5" height="20"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="49.5" height="20"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
-                                                <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <color key="textColor" systemColor="systemGrayColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vHl-A7-rxS">
-                                                <rect key="frame" x="53.5" y="0.0" width="10" height="20"/>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <rect key="frame" x="49.5" y="0.0" width="10" height="20"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="10" id="r9f-WC-Tqe"/>
                                                 </constraints>
                                             </view>
                                             <textField opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="ios-sdk-example-app" borderStyle="roundedRect" placeholder="Enter service name..." textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Uja-Qc-xBT">
-                                                <rect key="frame" x="63.5" y="0.0" width="320.5" height="20"/>
-                                                <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <rect key="frame" x="59.5" y="0.0" width="324.5" height="20"/>
+                                                <color key="textColor" systemColor="secondaryLabelColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
@@ -372,39 +393,39 @@
                                     </stackView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vyi-Ve-sU6" userLabel="Vertical gap 15">
                                         <rect key="frame" x="0.0" y="20" width="384" height="15"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="15" id="6sq-HI-uc9"/>
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Single span" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DX7-Qs-qSG">
-                                        <rect key="frame" x="0.0" y="35" width="384" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="35" width="384" height="17"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cuu-Jr-4xh" userLabel="Vertical gap 10">
-                                        <rect key="frame" x="0.0" y="55.5" width="384" height="10"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <rect key="frame" x="0.0" y="52" width="384" height="10"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="VcD-Rs-DRQ"/>
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="IS ERROR:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gfx-sC-buH">
-                                        <rect key="frame" x="0.0" y="65.5" width="384" height="14.5"/>
+                                        <rect key="frame" x="0.0" y="62" width="384" height="13.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
-                                        <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="textColor" systemColor="systemGrayColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ley-7v-fkh" userLabel="Vertical gap 5">
-                                        <rect key="frame" x="0.0" y="80" width="384" height="5"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <rect key="frame" x="0.0" y="75.5" width="384" height="5"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="5" id="czA-uK-CXA"/>
                                         </constraints>
                                     </view>
                                     <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="5do-J6-gQj">
-                                        <rect key="frame" x="0.0" y="85" width="384" height="45"/>
+                                        <rect key="frame" x="0.0" y="80.5" width="384" height="45"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="oRN-hL-yI9"/>
                                         </constraints>
@@ -414,27 +435,27 @@
                                         </segments>
                                     </segmentedControl>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4lr-UL-Ctp" userLabel="Vertical gap 10">
-                                        <rect key="frame" x="0.0" y="129" width="384" height="10"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <rect key="frame" x="0.0" y="124.5" width="384" height="10"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="mWq-qN-T8T"/>
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="OPERATION NAME" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ibf-ov-og2">
-                                        <rect key="frame" x="0.0" y="139" width="384" height="14.5"/>
+                                        <rect key="frame" x="0.0" y="134.5" width="384" height="13.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
-                                        <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="textColor" systemColor="systemGrayColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TEg-h0-oJ0" userLabel="Vertical gap 5">
-                                        <rect key="frame" x="0.0" y="153.5" width="384" height="5"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <rect key="frame" x="0.0" y="148" width="384" height="5"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="5" id="tPX-AN-TWk"/>
                                         </constraints>
                                     </view>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Enter operation name..." textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="1RN-ZZ-Uf5">
-                                        <rect key="frame" x="0.0" y="158.5" width="384" height="44"/>
+                                        <rect key="frame" x="0.0" y="153" width="384" height="44"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="KEe-LV-bPG"/>
                                         </constraints>
@@ -442,27 +463,27 @@
                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="continue" enablesReturnKeyAutomatically="YES" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
                                     </textField>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iyw-VO-Zma" userLabel="Vertical gap 10">
-                                        <rect key="frame" x="0.0" y="202.5" width="384" height="10"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <rect key="frame" x="0.0" y="197" width="384" height="10"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="7KZ-J6-u3c"/>
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="RESOURCE NAME" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CIm-Y6-2du">
-                                        <rect key="frame" x="0.0" y="212.5" width="384" height="14.5"/>
+                                        <rect key="frame" x="0.0" y="207" width="384" height="13.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
-                                        <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="textColor" systemColor="systemGrayColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eVC-sE-w0h" userLabel="Vertical gap 5">
-                                        <rect key="frame" x="0.0" y="227" width="384" height="5"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <rect key="frame" x="0.0" y="220.5" width="384" height="5"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="5" id="rd9-W8-LSF"/>
                                         </constraints>
                                     </view>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Enter resource name..." textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="O6r-wl-sFd">
-                                        <rect key="frame" x="0.0" y="232" width="384" height="44"/>
+                                        <rect key="frame" x="0.0" y="225.5" width="384" height="44"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="WPr-RI-Egu"/>
                                         </constraints>
@@ -470,14 +491,14 @@
                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="continue" enablesReturnKeyAutomatically="YES" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
                                     </textField>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bZW-Bh-rsg" userLabel="Vertical gap 10">
-                                        <rect key="frame" x="0.0" y="276" width="384" height="10"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <rect key="frame" x="0.0" y="269.5" width="384" height="10"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="bGV-Qi-s8z"/>
                                         </constraints>
                                     </view>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Z8K-Vl-XI8">
-                                        <rect key="frame" x="0.0" y="286" width="384" height="44"/>
+                                        <rect key="frame" x="0.0" y="279.5" width="384" height="44"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="v8U-xf-I9C">
                                                 <rect key="frame" x="0.0" y="0.0" width="384" height="44"/>
@@ -503,47 +524,47 @@
                                         </constraints>
                                     </stackView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ye7-9X-YIS" userLabel="Vertical gap 20">
-                                        <rect key="frame" x="0.0" y="330" width="384" height="20"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <rect key="frame" x="0.0" y="323.5" width="384" height="20"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="20" id="3Dl-pf-hL7"/>
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Complex spans hierarchy" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GsW-ex-CTl">
-                                        <rect key="frame" x="0.0" y="350" width="384" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="343.5" width="384" height="17"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aDC-NL-tAk" userLabel="Vertical gap 10">
-                                        <rect key="frame" x="0.0" y="370.5" width="384" height="10"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <rect key="frame" x="0.0" y="360.5" width="384" height="10"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="efG-2c-Dag"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gMD-8X-YiX" userLabel="Vertical gap 5">
-                                        <rect key="frame" x="0.0" y="380.5" width="384" height="5"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <rect key="frame" x="0.0" y="370.5" width="384" height="5"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="5" id="GYP-0A-9xf"/>
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ROOT OPERATION NAME" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yh6-Tm-ozZ">
-                                        <rect key="frame" x="0.0" y="385.5" width="384" height="14.5"/>
+                                        <rect key="frame" x="0.0" y="375.5" width="384" height="13.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
-                                        <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="textColor" systemColor="systemGrayColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lO3-mO-nzb" userLabel="Vertical gap 5">
-                                        <rect key="frame" x="0.0" y="400" width="384" height="5"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <rect key="frame" x="0.0" y="389" width="384" height="5"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="5" id="NE8-zr-Vi3"/>
                                         </constraints>
                                     </view>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Enter root operation name..." textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="WdR-er-YSX">
-                                        <rect key="frame" x="0.0" y="405" width="384" height="44"/>
+                                        <rect key="frame" x="0.0" y="394" width="384" height="44"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="UTv-Br-F8n"/>
                                         </constraints>
@@ -551,14 +572,14 @@
                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="continue" enablesReturnKeyAutomatically="YES" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
                                     </textField>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Sr3-sx-NOx" userLabel="Vertical gap 10">
-                                        <rect key="frame" x="0.0" y="449" width="384" height="10"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <rect key="frame" x="0.0" y="438" width="384" height="10"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="eOZ-ue-cej"/>
                                         </constraints>
                                     </view>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="tlp-TM-3R8">
-                                        <rect key="frame" x="0.0" y="459" width="384" height="44"/>
+                                        <rect key="frame" x="0.0" y="448" width="384" height="44"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="W8c-Yf-ICI">
                                                 <rect key="frame" x="0.0" y="0.0" width="384" height="44"/>
@@ -584,43 +605,43 @@
                                         </constraints>
                                     </stackView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bn8-jd-Xrh" userLabel="Vertical gap 10">
-                                        <rect key="frame" x="0.0" y="503" width="384" height="10"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <rect key="frame" x="0.0" y="492" width="384" height="10"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="GjS-fK-DeF"/>
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CONSOLE OUTPUT:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hyc-B5-Er9">
-                                        <rect key="frame" x="0.0" y="513" width="384" height="14.5"/>
+                                        <rect key="frame" x="0.0" y="502" width="384" height="13.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
-                                        <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="textColor" systemColor="systemGrayColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uBu-lq-4fT" userLabel="Vertical gap 10">
-                                        <rect key="frame" x="0.0" y="527.5" width="384" height="10"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <rect key="frame" x="0.0" y="515.5" width="384" height="10"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="vfa-Ap-dUP"/>
                                         </constraints>
                                     </view>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RFt-6W-lf2">
-                                        <rect key="frame" x="0.0" y="537.5" width="384" height="206.5"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                        <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <rect key="frame" x="0.0" y="525.5" width="384" height="218.5"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <color key="textColor" systemColor="systemGrayColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                     </textView>
                                 </subviews>
                             </stackView>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="lE0-s0-bki"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="h1b-K8-7lP" firstAttribute="leading" secondItem="lE0-s0-bki" secondAttribute="leading" constant="15" id="20u-J3-ieB"/>
                             <constraint firstItem="lE0-s0-bki" firstAttribute="bottom" secondItem="h1b-K8-7lP" secondAttribute="bottom" constant="15" id="IVs-3W-Pkc"/>
                             <constraint firstItem="h1b-K8-7lP" firstAttribute="top" secondItem="lE0-s0-bki" secondAttribute="top" constant="15" id="Lcn-YP-iMp"/>
                             <constraint firstItem="lE0-s0-bki" firstAttribute="trailing" secondItem="h1b-K8-7lP" secondAttribute="trailing" constant="15" id="aFw-or-J2M"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="lE0-s0-bki"/>
                     </view>
                     <navigationItem key="navigationItem" id="UPa-IX-v0z"/>
                     <connections>
@@ -638,6 +659,194 @@
             </objects>
             <point key="canvasLocation" x="-239" y="448"/>
         </scene>
+        <!--Debug Crash Reporting WithRUM View Controller-->
+        <scene sceneID="WLV-qS-ZZw">
+            <objects>
+                <viewController id="dzc-N5-XBR" customClass="DebugCrashReportingWithRUMViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="rP7-YE-4ya">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="HxE-NI-hW5">
+                                <rect key="frame" x="15" y="103" width="384" height="279.5"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pvE-Aw-hsS">
+                                        <rect key="frame" x="0.0" y="0.0" width="384" height="20"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" text="SERVICE:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5TO-9D-eiM">
+                                                <rect key="frame" x="0.0" y="0.0" width="49.5" height="20"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
+                                                <color key="textColor" systemColor="systemGrayColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HOE-UJ-SAj">
+                                                <rect key="frame" x="49.5" y="0.0" width="10" height="20"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="10" id="W4s-At-s8v"/>
+                                                </constraints>
+                                            </view>
+                                            <textField opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="ios-sdk-example-app" borderStyle="roundedRect" placeholder="Enter service name..." textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Bco-7y-w7S">
+                                                <rect key="frame" x="59.5" y="0.0" width="324.5" height="20"/>
+                                                <color key="textColor" systemColor="secondaryLabelColor"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="20" id="oly-zT-Qhz"/>
+                                        </constraints>
+                                    </stackView>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rCg-ye-Qa7" userLabel="Vertical gap 15">
+                                        <rect key="frame" x="0.0" y="20" width="384" height="15"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="15" id="QhF-R6-G7U"/>
+                                        </constraints>
+                                    </view>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Crash after starting RUM session" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cXc-Fh-bik">
+                                        <rect key="frame" x="0.0" y="35" width="384" height="17"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="shz-90-0DI" userLabel="Vertical gap 10">
+                                        <rect key="frame" x="0.0" y="52" width="384" height="10"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="10" id="agk-Sa-gb2"/>
+                                        </constraints>
+                                    </view>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="RUM view name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Pnx-V5-DK9">
+                                        <rect key="frame" x="0.0" y="62" width="384" height="13.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
+                                        <color key="textColor" systemColor="systemGrayColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hsj-LT-Upr" userLabel="Vertical gap 5">
+                                        <rect key="frame" x="0.0" y="75.5" width="384" height="5"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="5" id="uWd-OV-uFS"/>
+                                        </constraints>
+                                    </view>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Enter view name..." textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="bXI-gy-gbl">
+                                        <rect key="frame" x="0.0" y="80.5" width="384" height="44"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="dWj-uW-WXr"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="continue" enablesReturnKeyAutomatically="YES" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
+                                    </textField>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="S8F-cU-RD4" userLabel="Vertical gap 10">
+                                        <rect key="frame" x="0.0" y="124.5" width="384" height="10"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="10" id="vPc-6p-cVf"/>
+                                        </constraints>
+                                    </view>
+                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="mXq-pA-bHT">
+                                        <rect key="frame" x="0.0" y="134.5" width="384" height="44"/>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="akr-GH-lTT">
+                                                <rect key="frame" x="0.0" y="0.0" width="384" height="44"/>
+                                                <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                <state key="normal" title="Crash">
+                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </state>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="7"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="didTapCrashAfterStartingRUMSession:" destination="dzc-N5-XBR" eventType="touchUpInside" id="KJ2-fp-SeJ"/>
+                                                    <action selector="didTapSendSingleSpan:" destination="FaI-gu-eql" eventType="touchUpInside" id="fTI-dt-qjR"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="UcR-63-yMx"/>
+                                        </constraints>
+                                    </stackView>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hIn-Wj-pCN" userLabel="Vertical gap 20">
+                                        <rect key="frame" x="0.0" y="178.5" width="384" height="20"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="20" id="lh9-TG-Ca0"/>
+                                        </constraints>
+                                    </view>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Crash before starting RUM session" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4IZ-1R-3ol">
+                                        <rect key="frame" x="0.0" y="198.5" width="384" height="17"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5PJ-ie-0Ph" userLabel="Vertical gap 10">
+                                        <rect key="frame" x="0.0" y="215.5" width="384" height="10"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="10" id="cZ7-61-z1b"/>
+                                        </constraints>
+                                    </view>
+                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="W5u-HV-81t">
+                                        <rect key="frame" x="0.0" y="225.5" width="384" height="44"/>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZWr-O1-Jbs">
+                                                <rect key="frame" x="0.0" y="0.0" width="384" height="44"/>
+                                                <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                <state key="normal" title="Crash">
+                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </state>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="7"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="didTapCrashBeforeStartingRUMSession:" destination="dzc-N5-XBR" eventType="touchUpInside" id="eFK-Sd-n7b"/>
+                                                    <action selector="didTapSendComplexSpan:" destination="FaI-gu-eql" eventType="touchUpInside" id="AgP-cg-1zX"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="gVc-ED-141"/>
+                                        </constraints>
+                                    </stackView>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9L1-pY-mpL" userLabel="Vertical gap 10">
+                                        <rect key="frame" x="0.0" y="269.5" width="384" height="10"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="10" id="nRc-JH-2dv"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="KUE-EJ-J4G"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="KUE-EJ-J4G" firstAttribute="trailing" secondItem="HxE-NI-hW5" secondAttribute="trailing" constant="15" id="BQA-bh-ljl"/>
+                            <constraint firstItem="HxE-NI-hW5" firstAttribute="leading" secondItem="KUE-EJ-J4G" secondAttribute="leading" constant="15" id="mlf-MM-iFq"/>
+                            <constraint firstItem="HxE-NI-hW5" firstAttribute="top" secondItem="KUE-EJ-J4G" secondAttribute="top" constant="15" id="vxe-ww-dPa"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="UG5-SU-NkM"/>
+                    <connections>
+                        <outlet property="rumServiceNameTextField" destination="Bco-7y-w7S" id="cBg-pr-cZ4"/>
+                        <outlet property="viewNameTextField" destination="bXI-gy-gbl" id="Ep5-d7-sda"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="lEZ-pE-ASQ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-1194" y="1175"/>
+        </scene>
         <!--DebugRUM View Controller-->
         <scene sceneID="JCG-Nr-eCn">
             <objects>
@@ -653,21 +862,21 @@
                                         <rect key="frame" x="0.0" y="0.0" width="384" height="20"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" text="SERVICE:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Eka-Ej-HZy">
-                                                <rect key="frame" x="0.0" y="0.0" width="53.5" height="20"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="49.5" height="20"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
-                                                <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <color key="textColor" systemColor="systemGrayColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="t9m-tT-F8j">
-                                                <rect key="frame" x="53.5" y="0.0" width="10" height="20"/>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <rect key="frame" x="49.5" y="0.0" width="10" height="20"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="10" id="Wwl-46-fmK"/>
                                                 </constraints>
                                             </view>
                                             <textField opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="ios-sdk-example-app" borderStyle="roundedRect" placeholder="Enter service name..." textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="vzP-ny-3dq">
-                                                <rect key="frame" x="63.5" y="0.0" width="320.5" height="20"/>
-                                                <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <rect key="frame" x="59.5" y="0.0" width="324.5" height="20"/>
+                                                <color key="textColor" systemColor="secondaryLabelColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
@@ -677,30 +886,30 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="e81-o8-mqx" userLabel="View Event">
-                                        <rect key="frame" x="0.0" y="20" width="384" height="75.5"/>
+                                        <rect key="frame" x="0.0" y="20" width="384" height="72"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fM2-qe-QkK" userLabel="Vertical gap 15">
                                                 <rect key="frame" x="0.0" y="0.0" width="384" height="15"/>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="15" id="wcN-Gv-yCO"/>
                                                 </constraints>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="View Event" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zjv-y9-VvL">
-                                                <rect key="frame" x="0.0" y="15" width="384" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="15" width="384" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DmQ-rb-UiO" userLabel="Vertical gap 10">
-                                                <rect key="frame" x="0.0" y="35.5" width="384" height="10"/>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <rect key="frame" x="0.0" y="32" width="384" height="10"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="10" id="0En-Yf-gGB"/>
                                                 </constraints>
                                             </view>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="abs-xz-lgo">
-                                                <rect key="frame" x="0.0" y="45.5" width="384" height="30"/>
+                                                <rect key="frame" x="0.0" y="42" width="384" height="30"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="79A-KI-slP">
                                                         <rect key="frame" x="0.0" y="0.0" width="329" height="30"/>
@@ -709,13 +918,13 @@
                                                                 <rect key="frame" x="0.0" y="0.0" width="329" height="30"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="view.url" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QS9-fr-2yR">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="43" height="30"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="40" height="30"/>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
-                                                                        <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                        <color key="textColor" systemColor="systemGrayColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="U9s-H3-pzA">
-                                                                        <rect key="frame" x="48" y="0.0" width="281" height="30"/>
+                                                                        <rect key="frame" x="45" y="0.0" width="284" height="30"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="continue" enablesReturnKeyAutomatically="YES" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
                                                                     </textField>
@@ -752,30 +961,30 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="EoW-hq-iwp" userLabel="Action Event">
-                                        <rect key="frame" x="0.0" y="95.5" width="384" height="105.5"/>
+                                        <rect key="frame" x="0.0" y="92" width="384" height="102"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xge-K9-YNh" userLabel="Vertical gap 15">
                                                 <rect key="frame" x="0.0" y="0.0" width="384" height="15"/>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="15" id="lTB-PH-2wv"/>
                                                 </constraints>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Action Event" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wRU-yO-WNe">
-                                                <rect key="frame" x="0.0" y="15" width="384" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="15" width="384" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TDR-6h-k8W" userLabel="Vertical gap 10">
-                                                <rect key="frame" x="0.0" y="35.5" width="384" height="10"/>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <rect key="frame" x="0.0" y="32" width="384" height="10"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="10" id="Lqf-ua-fgv"/>
                                                 </constraints>
                                             </view>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="fDD-nV-d90">
-                                                <rect key="frame" x="0.0" y="45.5" width="384" height="60"/>
+                                                <rect key="frame" x="0.0" y="42" width="384" height="60"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="VFn-cp-8QB">
                                                         <rect key="frame" x="0.0" y="0.0" width="329" height="60"/>
@@ -784,13 +993,13 @@
                                                                 <rect key="frame" x="0.0" y="0.0" width="329" height="30"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="view.url" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yFp-ta-kUm">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="43" height="30"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="40" height="30"/>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
-                                                                        <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                        <color key="textColor" systemColor="systemGrayColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="vhd-M4-bzl">
-                                                                        <rect key="frame" x="48" y="0.0" width="281" height="30"/>
+                                                                        <rect key="frame" x="45" y="0.0" width="284" height="30"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="continue" enablesReturnKeyAutomatically="YES" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
                                                                     </textField>
@@ -803,13 +1012,13 @@
                                                                 <rect key="frame" x="0.0" y="30" width="329" height="30"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="action.type" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AjS-Id-uD9">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="63.5" height="30"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="59" height="30"/>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
-                                                                        <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                        <color key="textColor" systemColor="systemGrayColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="AzU-sp-7lm">
-                                                                        <rect key="frame" x="68.5" y="0.0" width="260.5" height="30"/>
+                                                                        <rect key="frame" x="64" y="0.0" width="265" height="30"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="continue" enablesReturnKeyAutomatically="YES" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
                                                                     </textField>
@@ -846,30 +1055,30 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="gmK-cB-MeK" userLabel="Resource Event">
-                                        <rect key="frame" x="0.0" y="201" width="384" height="105.5"/>
+                                        <rect key="frame" x="0.0" y="194" width="384" height="102"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lmP-RX-JRw" userLabel="Vertical gap 15">
                                                 <rect key="frame" x="0.0" y="0.0" width="384" height="15"/>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="15" id="xLd-uF-LMm"/>
                                                 </constraints>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Resource Event" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CN8-y2-J5a">
-                                                <rect key="frame" x="0.0" y="15" width="384" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="15" width="384" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AJK-Wb-frZ" userLabel="Vertical gap 10">
-                                                <rect key="frame" x="0.0" y="35.5" width="384" height="10"/>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <rect key="frame" x="0.0" y="32" width="384" height="10"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="10" id="tyX-cw-Sbz"/>
                                                 </constraints>
                                             </view>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="YxY-We-gJ0">
-                                                <rect key="frame" x="0.0" y="45.5" width="384" height="60"/>
+                                                <rect key="frame" x="0.0" y="42" width="384" height="60"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="OjT-bZ-PeB">
                                                         <rect key="frame" x="0.0" y="0.0" width="329" height="60"/>
@@ -878,13 +1087,13 @@
                                                                 <rect key="frame" x="0.0" y="0.0" width="329" height="30"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="view.url" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="j2C-yW-r83">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="43" height="30"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="40" height="30"/>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
-                                                                        <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                        <color key="textColor" systemColor="systemGrayColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="Rlu-N1-eFy">
-                                                                        <rect key="frame" x="48" y="0.0" width="281" height="30"/>
+                                                                        <rect key="frame" x="45" y="0.0" width="284" height="30"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="continue" enablesReturnKeyAutomatically="YES" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
                                                                     </textField>
@@ -897,13 +1106,13 @@
                                                                 <rect key="frame" x="0.0" y="30" width="329" height="30"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="resource.url" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Mhk-NZ-U8q">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="68" height="30"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="63" height="30"/>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
-                                                                        <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                        <color key="textColor" systemColor="systemGrayColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="lWm-uh-OR0">
-                                                                        <rect key="frame" x="73" y="0.0" width="256" height="30"/>
+                                                                        <rect key="frame" x="68" y="0.0" width="261" height="30"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="continue" enablesReturnKeyAutomatically="YES" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
                                                                     </textField>
@@ -940,30 +1149,30 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="hja-B4-mbG" userLabel="Error Event">
-                                        <rect key="frame" x="0.0" y="306.5" width="384" height="105.5"/>
+                                        <rect key="frame" x="0.0" y="296" width="384" height="102"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sD5-qX-4vo" userLabel="Vertical gap 15">
                                                 <rect key="frame" x="0.0" y="0.0" width="384" height="15"/>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="15" id="J5f-FO-JVo"/>
                                                 </constraints>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Error Event" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CJm-JE-3gF">
-                                                <rect key="frame" x="0.0" y="15" width="384" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="15" width="384" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fRD-aF-9Uf" userLabel="Vertical gap 10">
-                                                <rect key="frame" x="0.0" y="35.5" width="384" height="10"/>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <rect key="frame" x="0.0" y="32" width="384" height="10"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="10" id="isj-v5-foA"/>
                                                 </constraints>
                                             </view>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="YlW-a0-eL5">
-                                                <rect key="frame" x="0.0" y="45.5" width="384" height="60"/>
+                                                <rect key="frame" x="0.0" y="42" width="384" height="60"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="fw1-DV-kj9">
                                                         <rect key="frame" x="0.0" y="0.0" width="329" height="60"/>
@@ -972,13 +1181,13 @@
                                                                 <rect key="frame" x="0.0" y="0.0" width="329" height="30"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="view.url" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cNk-uW-YDz">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="43" height="30"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="40" height="30"/>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
-                                                                        <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                        <color key="textColor" systemColor="systemGrayColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="bis-gb-e0x">
-                                                                        <rect key="frame" x="48" y="0.0" width="281" height="30"/>
+                                                                        <rect key="frame" x="45" y="0.0" width="284" height="30"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="continue" enablesReturnKeyAutomatically="YES" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
                                                                     </textField>
@@ -991,13 +1200,13 @@
                                                                 <rect key="frame" x="0.0" y="30" width="329" height="30"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="error.message" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3eH-fL-pPC">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="81" height="30"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="75.5" height="30"/>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
-                                                                        <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                        <color key="textColor" systemColor="systemGrayColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="X8j-yY-dUj">
-                                                                        <rect key="frame" x="86" y="0.0" width="243" height="30"/>
+                                                                        <rect key="frame" x="80.5" y="0.0" width="248.5" height="30"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="continue" enablesReturnKeyAutomatically="YES" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
                                                                     </textField>
@@ -1034,50 +1243,50 @@
                                         </subviews>
                                     </stackView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="W1b-Ap-trU" userLabel="Vertical gap 10">
-                                        <rect key="frame" x="0.0" y="412" width="384" height="10"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <rect key="frame" x="0.0" y="398" width="384" height="10"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="Zk1-nz-tiQ"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1CX-Pk-Oad" userLabel="Vertical gap 10">
-                                        <rect key="frame" x="0.0" y="422" width="384" height="10"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <rect key="frame" x="0.0" y="408" width="384" height="10"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="J1D-8z-qtE"/>
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CONSOLE OUTPUT:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="heX-eV-XM4">
-                                        <rect key="frame" x="0.0" y="432" width="384" height="14.5"/>
+                                        <rect key="frame" x="0.0" y="418" width="384" height="13.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
-                                        <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="textColor" systemColor="systemGrayColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cUF-XZ-rO4" userLabel="Vertical gap 10">
-                                        <rect key="frame" x="0.0" y="446.5" width="384" height="10"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <rect key="frame" x="0.0" y="431.5" width="384" height="10"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="Kmx-dC-T5D"/>
                                         </constraints>
                                     </view>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xE1-F9-dzh">
-                                        <rect key="frame" x="0.0" y="456.5" width="384" height="287.5"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                        <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <rect key="frame" x="0.0" y="441.5" width="384" height="302.5"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <color key="textColor" systemColor="systemGrayColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                     </textView>
                                 </subviews>
                             </stackView>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="bZp-wc-KwC"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="Il3-pF-p3a" firstAttribute="top" secondItem="bZp-wc-KwC" secondAttribute="top" constant="15" id="5X6-Dm-xjN"/>
                             <constraint firstItem="bZp-wc-KwC" firstAttribute="trailing" secondItem="Il3-pF-p3a" secondAttribute="trailing" constant="15" id="V2B-EN-ONG"/>
                             <constraint firstItem="Il3-pF-p3a" firstAttribute="leading" secondItem="bZp-wc-KwC" secondAttribute="leading" constant="15" id="VLL-yL-8P0"/>
                             <constraint firstItem="bZp-wc-KwC" firstAttribute="bottom" secondItem="Il3-pF-p3a" secondAttribute="bottom" constant="15" id="vsV-h4-zjs"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="bZp-wc-KwC"/>
                     </view>
                     <navigationItem key="navigationItem" id="uWQ-hu-SiG"/>
                     <connections>
@@ -1101,4 +1310,15 @@
             <point key="canvasLocation" x="-239" y="1175"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGrayColor">
+            <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Datadog/Example/Debugging/DebugCrashReportingWithRUMViewController.swift
+++ b/Datadog/Example/Debugging/DebugCrashReportingWithRUMViewController.swift
@@ -1,0 +1,51 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import UIKit
+import Datadog
+
+class DebugCrashReportingWithRUMViewController: UIViewController {
+    @IBOutlet weak var rumServiceNameTextField: UITextField!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        rumServiceNameTextField.text = (appConfiguration as? ExampleAppConfiguration)?.serviceName
+
+        viewNameTextField.placeholder = viewName
+    }
+
+    private func crash() {
+        let objc = CrashReportingObjcHelpers()
+        objc.throwUncaughtNSException()
+    }
+
+    // MARK: - Crash after starting RUM session
+
+    @IBOutlet weak var viewNameTextField: UITextField!
+
+    private var viewName: String {
+        viewNameTextField.text!.isEmpty ? "FooViewController" : viewNameTextField.text!
+    }
+
+    @IBAction func didTapCrashAfterStartingRUMSession(_ sender: Any) {
+        (sender as? UIButton)?.disableFor(seconds: 0.5)
+
+        rumMonitor.startView(key: viewName, name: viewName, attributes: [:])
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            self?.crash()
+        }
+    }
+
+    // MARK: - Crash before starting RUM session
+
+    @IBAction func didTapCrashBeforeStartingRUMSession(_ sender: Any) {
+        (sender as? UIButton)?.disableFor(seconds: 0.5)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            self?.crash()
+        }
+    }
+}

--- a/DatadogSDK.podspec
+++ b/DatadogSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSDK"
   s.module_name  = "Datadog"
-  s.version      = "1.7.0-beta4"
+  s.version      = "1.7.0"
   s.summary      = "Official Datadog Swift SDK for iOS."
   
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogSDKAlamofireExtension.podspec
+++ b/DatadogSDKAlamofireExtension.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSDKAlamofireExtension"
   s.module_name  = "DatadogAlamofireExtension"
-  s.version      = "1.7.0-beta4"
+  s.version      = "1.7.0"
   s.summary      = "An Official Extensions of Datadog Swift SDK for Alamofire."
   
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogSDKCrashReporting.podspec
+++ b/DatadogSDKCrashReporting.podspec
@@ -21,5 +21,5 @@ Pod::Spec.new do |s|
 
   s.source_files = "Sources/DatadogCrashReporting/**/*.swift"
   s.dependency 'DatadogSDK', '1.7.0-beta4'
-  s.dependency 'PLCrashReporter', '~> 1.8.1'
+  s.dependency 'PLCrashReporter', '~> 1.10.0'
 end

--- a/DatadogSDKCrashReporting.podspec
+++ b/DatadogSDKCrashReporting.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSDKCrashReporting"
   s.module_name  = "DatadogCrashReporting"
-  s.version      = "1.7.0-beta4"
+  s.version      = "1.7.0"
   s.summary      = "Official Datadog Crash Reporting SDK for iOS."
   
   s.homepage     = "https://www.datadoghq.com"
@@ -20,6 +20,6 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.source_files = "Sources/DatadogCrashReporting/**/*.swift"
-  s.dependency 'DatadogSDK', '1.7.0-beta4'
+  s.dependency 'DatadogSDK', '1.7.0'
   s.dependency 'PLCrashReporter', '~> 1.10.0'
 end

--- a/DatadogSDKCrashReporting.podspec.src
+++ b/DatadogSDKCrashReporting.podspec.src
@@ -21,5 +21,5 @@ Pod::Spec.new do |s|
 
   s.source_files = "Sources/DatadogCrashReporting/**/*.swift"
   s.dependency 'DatadogSDK', '__DATADOG_VERSION__'
-  s.dependency 'PLCrashReporter', '~> 1.8.1'
+  s.dependency 'PLCrashReporter', '~> 1.10.0'
 end

--- a/DatadogSDKObjc.podspec
+++ b/DatadogSDKObjc.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSDKObjc"
   s.module_name  = "DatadogObjc"
-  s.version      = "1.7.0-beta4"
+  s.version      = "1.7.0"
   s.summary      = "Official Datadog Objective-C SDK for iOS."
   
   s.homepage     = "https://www.datadoghq.com"
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/DataDog/dd-sdk-ios.git', :tag => s.version.to_s }
 
   s.source_files = "Sources/DatadogObjc/**/*.swift"
-  s.dependency 'DatadogSDK', '1.7.0-beta4'
+  s.dependency 'DatadogSDK', '1.7.0'
 end

--- a/LICENSE
+++ b/LICENSE
@@ -178,7 +178,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
+      boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "Kronos", url: "https://github.com/lyft/Kronos.git", from: "4.2.1"),
-        .package(name: "PLCrashReporter", url: "https://github.com/microsoft/plcrashreporter.git", from: "1.8.1"),
+        .package(name: "PLCrashReporter", url: "https://github.com/microsoft/plcrashreporter.git", from: "1.10.0"),
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ See the dedicated [Datadog iOS Log Collection](https://docs.datadoghq.com/logs/l
 
 ### Trace Collection
 
-See [Datadog iOS Trace Collection](https://docs.datadoghq.com/tracing/setup/ios/?tab=us) documentation to try it out.
+See [Datadog iOS Trace Collection](https://docs.datadoghq.com/tracing/setup_overview/setup/ios/?tab=us) documentation to try it out.
 
 ![Datadog iOS Log Collection](docs/images/tracing.png)
 

--- a/Sources/Datadog/Core/System/MobileDevice.swift
+++ b/Sources/Datadog/Core/System/MobileDevice.swift
@@ -54,6 +54,7 @@ internal class MobileDevice {
 
     convenience init(uiDevice: UIDevice, processInfo: ProcessInfo) {
         let wasBatteryMonitoringEnabled = uiDevice.isBatteryMonitoringEnabled
+        let lowPowerModeMonitor = LowPowerModeMonitor(processInfo)
         self.init(
             model: uiDevice.model,
             osName: uiDevice.systemName,
@@ -64,12 +65,12 @@ internal class MobileDevice {
                 return BatteryStatus(
                     state: MobileDevice.toBatteryState(uiDevice.batteryState),
                     level: uiDevice.batteryLevel,
-                    isLowPowerModeEnabled: processInfo.isLowPowerModeEnabled
+                    isLowPowerModeEnabled: lowPowerModeMonitor.isLowPowerModeEnabled
                 )
             }
         )
     }
-
+    
     /// Returns current mobile device  if `UIDevice` is available on this platform.
     /// On other platforms returns `nil`.
     static var current: MobileDevice {
@@ -96,6 +97,32 @@ internal class MobileDevice {
         case .charging:     return .charging
         case .full:         return .full
         @unknown default:   return.unknown
+        }
+    }
+}
+
+private class LowPowerModeMonitor {
+    
+    var isLowPowerModeEnabled = false
+    private var powerStateDidChangeObserver: Any?
+    
+    init(_ processInfo: ProcessInfo) {
+        isLowPowerModeEnabled = processInfo.isLowPowerModeEnabled
+        powerStateDidChangeObserver = NotificationCenter
+            .default
+            .addObserver(forName: .NSProcessInfoPowerStateDidChange,
+                         object: nil,
+                         queue: .main) { [weak self] notification in
+                guard let processInfo = notification.object as? ProcessInfo else {
+                    return
+                }
+                self?.isLowPowerModeEnabled = processInfo.isLowPowerModeEnabled
+            }
+    }
+    
+    deinit {
+        if let observer = powerStateDidChangeObserver {
+            NotificationCenter.default.removeObserver(observer)
         }
     }
 }

--- a/Sources/Datadog/Core/System/MobileDevice.swift
+++ b/Sources/Datadog/Core/System/MobileDevice.swift
@@ -70,7 +70,6 @@ internal class MobileDevice {
             }
         )
     }
-    
     /// Returns current mobile device  if `UIDevice` is available on this platform.
     /// On other platforms returns `nil`.
     static var current: MobileDevice {
@@ -102,29 +101,26 @@ internal class MobileDevice {
 }
 
 private final class LowPowerModeMonitor {
-    
     var isLowPowerModeEnabled: Bool {
         publisher.currentValue
     }
-    
     private var publisher: ValuePublisher<Bool>
     private var powerStateDidChangeObserver: Any?
-    
     init(_ processInfo: ProcessInfo) {
         publisher = ValuePublisher(initialValue: processInfo.isLowPowerModeEnabled)
-        
         powerStateDidChangeObserver = NotificationCenter
             .default
-            .addObserver(forName: .NSProcessInfoPowerStateDidChange,
-                         object: nil,
-                         queue: .main) { [weak self] notification in
+            .addObserver(
+                forName: .NSProcessInfoPowerStateDidChange,
+                object: nil,
+                queue: .main
+            ) { [weak self] notification in
                 guard let processInfo = notification.object as? ProcessInfo else {
                     return
                 }
                 self?.publisher.publishAsync(processInfo.isLowPowerModeEnabled)
             }
     }
-    
     deinit {
         if let observer = powerStateDidChangeObserver {
             NotificationCenter.default.removeObserver(observer)

--- a/Sources/Datadog/Core/System/MobileDevice.swift
+++ b/Sources/Datadog/Core/System/MobileDevice.swift
@@ -101,13 +101,18 @@ internal class MobileDevice {
     }
 }
 
-private class LowPowerModeMonitor {
+private final class LowPowerModeMonitor {
     
-    var isLowPowerModeEnabled = false
+    var isLowPowerModeEnabled: Bool {
+        publisher.currentValue
+    }
+    
+    private var publisher: ValuePublisher<Bool>
     private var powerStateDidChangeObserver: Any?
     
     init(_ processInfo: ProcessInfo) {
-        isLowPowerModeEnabled = processInfo.isLowPowerModeEnabled
+        publisher = ValuePublisher(initialValue: processInfo.isLowPowerModeEnabled)
+        
         powerStateDidChangeObserver = NotificationCenter
             .default
             .addObserver(forName: .NSProcessInfoPowerStateDidChange,
@@ -116,7 +121,7 @@ private class LowPowerModeMonitor {
                 guard let processInfo = notification.object as? ProcessInfo else {
                     return
                 }
-                self?.isLowPowerModeEnabled = processInfo.isLowPowerModeEnabled
+                self?.publisher.publishAsync(processInfo.isLowPowerModeEnabled)
             }
     }
     

--- a/Sources/Datadog/Core/System/Time/ServerDateProvider.swift
+++ b/Sources/Datadog/Core/System/Time/ServerDateProvider.swift
@@ -10,21 +10,41 @@ import Kronos
 /// Abstract the monotonic clock synchronized with the server using NTP.
 internal protocol ServerDateProvider {
     /// Start the clock synchronisation with NTP server.
-    /// Calls the `completion` by passing it the server time when the synchronization succeeds or`nil` if it fails.
-    func synchronize(with ntpPool: String, completion: @escaping (Date?) -> Void)
-    /// Returns the server time or `nil` if not yet determined.
-    /// This time gets more precise while synchronization is pending.
-    func currentDate() -> Date?
+    /// Calls the `completion` by passing it the server time offset when the synchronization succeeds or`nil` if it fails.
+    func synchronize(with pool: String, completion: @escaping (TimeInterval?) -> Void)
+    /// Returns the server time offset or `nil` if not yet determined.
+    /// This offset gets more precise while synchronization is pending.
+    var offset: TimeInterval? { get }
 }
 
 internal class NTPServerDateProvider: ServerDateProvider {
-    func synchronize(with ntpPool: String, completion: @escaping (Date?) -> Void) {
-        Clock.sync(from: ntpPool, completion: { serverTime, _ in
-            completion(serverTime)
-        })
+    /// Server offset publisher.
+    private let publisher: ValuePublisher<TimeInterval?> = ValuePublisher(initialValue: nil)
+
+    /// Returns the server time offset or `nil` if not yet determined.
+    /// This offset gets more precise while synchronization is pending.
+    var offset: TimeInterval? {
+        return publisher.currentValue
     }
 
-    func currentDate() -> Date? {
-        return Clock.now
+    func synchronize(with pool: String, completion: @escaping (TimeInterval?) -> Void) {
+        // Kronos only notifies for the first and last samples.
+        // In case, the last sample does not return an offset, we calculate the offset
+        // from `Clock.now`.
+        Clock.sync(
+            from: pool,
+            first: { _, offset in
+                self.publisher.publishAsync(offset)
+            },
+            completion: { now, offset in
+                if let offset = offset {
+                    self.publisher.publishAsync(offset)
+                } else if let now = now {
+                    self.publisher.publishAsync(now.timeIntervalSinceNow)
+                }
+
+                completion(self.publisher.currentValue)
+            }
+        )
     }
 }

--- a/Sources/Datadog/Core/System/Time/ServerDateProvider.swift
+++ b/Sources/Datadog/Core/System/Time/ServerDateProvider.swift
@@ -47,5 +47,9 @@ internal class NTPServerDateProvider: ServerDateProvider {
                 completion(self?.publisher.currentValue)
             }
         )
+
+        // `Kronos.sync` first loads the previous state from the `UserDefaults` if any.
+        // We can invoke `Clock.now` to retrieve the stored offset.
+        publisher.publishAsync(Clock.now?.timeIntervalSinceNow)
     }
 }

--- a/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
+++ b/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
@@ -39,6 +39,8 @@ internal final class VitalInfoSampler {
 
     var refreshRate: VitalInfo {
         let info = refreshRatePublisher.currentValue
+        // NOTE: RUMM-1278 refreshRate is normalized to 0...60 range
+        // assuming 60 is the industry standard.
         return info.scaledDown(by: maximumRefreshRate / 60.0)
     }
 

--- a/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
+++ b/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
@@ -17,6 +17,12 @@ internal protocol ContinuousVitalReader {
 }
 
 internal final class VitalInfoSampler {
+    struct Constants {
+        // We use normalized 0...60 range for refresh rate in Mobile Vitals,
+        // assuming 60 is the industry standard.
+        static let normalizedRefreshRate = 60.0
+    }
+
     private static let frequency: TimeInterval = 1.0
 
     let cpuReader: SamplingBasedVitalReader
@@ -39,9 +45,7 @@ internal final class VitalInfoSampler {
 
     var refreshRate: VitalInfo {
         let info = refreshRatePublisher.currentValue
-        // NOTE: RUMM-1278 refreshRate is normalized to 0...60 range
-        // assuming 60 is the industry standard.
-        return info.scaledDown(by: maximumRefreshRate / 60.0)
+        return info.scaledDown(by: maximumRefreshRate / Constants.normalizedRefreshRate)
     }
 
     private var timer: Timer?

--- a/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
+++ b/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
@@ -39,7 +39,7 @@ internal final class VitalInfoSampler {
 
     var refreshRate: VitalInfo {
         let info = refreshRatePublisher.currentValue
-        return info.scaledDown(by: maximumRefreshRate)
+        return info.scaledDown(by: maximumRefreshRate / 60.0)
     }
 
     private var timer: Timer?

--- a/Sources/Datadog/Tracing/DDNoOps.swift
+++ b/Sources/Datadog/Tracing/DDNoOps.swift
@@ -20,7 +20,7 @@ internal struct DDNoopTracer: OTTracer {
             """
             The `Global.sharedTracer` was called but no `Tracer` is registered. Configure and register the `Tracer` globally before invoking the feature:
                 Global.sharedTracer = Tracer.initialize()
-            See https://docs.datadoghq.com/tracing/setup/ios
+            See https://docs.datadoghq.com/tracing/setup_overview/setup/ios
             """
         )
     }

--- a/Sources/Datadog/Versioning.swift
+++ b/Sources/Datadog/Versioning.swift
@@ -1,3 +1,3 @@
 // GENERATED FILE: Do not edit directly
 
-internal let sdkVersion = "1.7.0-beta4"
+internal let sdkVersion = "1.7.0"

--- a/Sources/DatadogCrashReporting/PLCrashReporterIntegration/CrashReport.swift
+++ b/Sources/DatadogCrashReporting/PLCrashReporterIntegration/CrashReport.swift
@@ -241,8 +241,12 @@ extension BinaryImageInfo {
 
         self.uuid = imageUUID
         self.imageName = URL(string: imagePath)?.lastPathComponent
-        // NOTE: RUMM-1492 refer to JIRA ticket or `CrashReportTests.swift` to see imagePath examples
-        self.isSystemImage = !imagePath.contains("/Bundle/Application/") || imagePath.contains("/Contents/Developer/Platforms/")
+
+        #if targetEnvironment(simulator)
+        self.isSystemImage = Self.isPathSystemImageInSimulator(imagePath)
+        #else
+        self.isSystemImage = Self.isPathSystemImageInDevice(imagePath)
+        #endif
 
         if let codeType = imageInfo.codeType {
             self.codeType = CodeType(from: codeType)
@@ -253,6 +257,17 @@ extension BinaryImageInfo {
 
         self.imageBaseAddress = imageInfo.imageBaseAddress
         self.imageSize = imageInfo.imageSize
+    }
+
+    static func isPathSystemImageInSimulator(_ path: String) -> Bool {
+        // in simulator, example system image path: ~/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/...
+        return path.contains("/Contents/Developer/Platforms/")
+    }
+
+    static func isPathSystemImageInDevice(_ path: String) -> Bool {
+        // in device, example user image path: .../containers/Bundle/Application/0000/Example.app/Frameworks/...
+        let isUserImage = path.contains("/Bundle/Application/")
+        return !isUserImage
     }
 }
 

--- a/Sources/DatadogCrashReporting/PLCrashReporterIntegration/PLCrashReporterIntegration.swift
+++ b/Sources/DatadogCrashReporting/PLCrashReporterIntegration/PLCrashReporterIntegration.swift
@@ -7,20 +7,25 @@
 import CrashReporter
 import Datadog
 
+internal extension PLCrashReporterConfig {
+    /// `PLCR` configuration used for `DatadogCrashReporting`
+    static func ddConfiguration() -> PLCrashReporterConfig {
+        return PLCrashReporterConfig(
+            // The choice of `.BSD` over `.mach` is well discussed here:
+            // https://github.com/ChatSecure/PLCrashReporter/blob/7f27b272d5ff0d6650fc41317127bb2378ed6e88/Source/CrashReporter.h#L238-L363
+            signalHandlerType: .BSD,
+            // We don't symbolicate on device. All symbolication will happen backend-side.
+            symbolicationStrategy: []
+        )
+    }
+}
+
 internal final class PLCrashReporterIntegration: ThirdPartyCrashReporter {
     private let crashReporter: PLCrashReporter
     private let builder = DDCrashReportBuilder()
 
     init() throws {
-        self.crashReporter = PLCrashReporter(
-            configuration: PLCrashReporterConfig(
-                // The choice of `.BSD` over `.mach` is well discussed here:
-                // https://github.com/ChatSecure/PLCrashReporter/blob/7f27b272d5ff0d6650fc41317127bb2378ed6e88/Source/CrashReporter.h#L238-L363
-                signalHandlerType: .BSD,
-                // We don't symbolicate on device. All symbolication will happen backend-side.
-                symbolicationStrategy: []
-            )
-        )
+        self.crashReporter = PLCrashReporter(configuration: .ddConfiguration())
         try crashReporter.enableAndReturnError()
     }
 

--- a/Sources/DatadogExtensions/Alamofire/README.md
+++ b/Sources/DatadogExtensions/Alamofire/README.md
@@ -47,5 +47,5 @@ Pull requests are welcome. First, open an issue to discuss what you would like t
 [1]: https://github.com/Alamofire/Alamofire
 [2]: https://github.com/Carthage/Carthage
 [3]: https://swift.org/package-manager/
-[4]: https://docs.datadoghq.com/tracing/setup/ios/
+[4]: https://docs.datadoghq.com/tracing/setup_overview/setup/ios/
 [5]: https://docs.datadoghq.com/real_user_monitoring/ios

--- a/Tests/DatadogCrashReportingTests/PLCrashReporterIntegration/DDCrashReportBuilderTests.swift
+++ b/Tests/DatadogCrashReportingTests/PLCrashReporterIntegration/DDCrashReportBuilderTests.swift
@@ -43,7 +43,8 @@ class DDCrashReportBuilderTests: XCTestCase {
             "`DDCrashReport` should include the image for `DatadogCrashReportingTests`"
         )
         XCTAssertTrue(
-            ddCrashReport.binaryImages.contains(where: { $0.libraryName == "XCTest" }),
+            // Assert on prefix as it's `XCTestCore` on iOS 15+ and `XCTest` earlier:
+            ddCrashReport.binaryImages.contains(where: { $0.libraryName.hasPrefix("XCTest") }),
             "`DDCrashReport` should include the image for `XCTest`"
         )
     }

--- a/Tests/DatadogCrashReportingTests/PLCrashReporterIntegration/DDCrashReportExporterTests.swift
+++ b/Tests/DatadogCrashReportingTests/PLCrashReporterIntegration/DDCrashReportExporterTests.swift
@@ -7,6 +7,7 @@
 import XCTest
 @testable import Datadog
 @testable import DatadogCrashReporting
+import CrashReporter
 
 class DDCrashReportExporterTests: XCTestCase {
     private let exporter = DDCrashReportExporter()
@@ -355,5 +356,73 @@ class DDCrashReportExporterTests: XCTestCase {
         let randomFlag: Bool = .random()
         crashReport.wasTruncated = randomFlag
         XCTAssertEqual(exporter.export(crashReport).wasTruncated, randomFlag)
+    }
+
+    // MARK: - Comparing with PLCR text format
+
+    func testExportedStacksHaveTheSameFormatAndValuesAsIfTheyWereExportedFromPLCR() throws {
+        let crashReporter = PLCrashReporter(configuration: .ddConfiguration())!
+
+        // Given
+        let plCrashReport = try PLCrashReport(
+            data: try crashReporter.generateLiveReportAndReturnError()
+        )
+
+        // When
+        let exporter = DDCrashReportExporter()
+        let ddCrashReport = exporter.export(try CrashReport(from: plCrashReport))
+
+        // Then
+        let plcrTextFormat = PLCrashReportTextFormatter.stringValue(for: plCrashReport, with: PLCrashReportTextFormatiOS)!
+
+        ddCrashReport.threads.forEach { thread in
+            XCTAssertTrue(
+                plcrTextFormat.contains(thread.stack),
+                """
+                Stack:
+                ```
+                \(thread.stack)
+                ```
+
+                does not appear in PLCR text format:
+                ```
+                \(plcrTextFormat)
+                ```
+                """
+            )
+        }
+    }
+
+    func testExportedBinaryImagesHaveTheSameValuesAsIfTheyWereExportedFromPLCR() throws {
+        let crashReporter = PLCrashReporter(configuration: .ddConfiguration())!
+
+        // Given
+        let plCrashReport = try PLCrashReport(
+            data: try crashReporter.generateLiveReportAndReturnError()
+        )
+
+        // When
+        let exporter = DDCrashReportExporter()
+        let ddCrashReport = exporter.export(try CrashReport(from: plCrashReport))
+
+        // Then
+        let plcrTextFormat = PLCrashReportTextFormatter.stringValue(for: plCrashReport, with: PLCrashReportTextFormatiOS)!
+        let plcrByLines = plcrTextFormat.split(separator: "\n").reversed() // matching in reversed report is 2x faster
+
+        ddCrashReport.binaryImages.forEach { binaryImage in
+            XCTAssertTrue(
+                plcrByLines.contains { line in
+                    // PLCR uses free-form text format, e.g.:
+                    // `       0x10ce2e000 -        0x10ced9fff +Example x86_64  <aaf339bd11e1347a91fcefdce2714ad7> /.../Example.app/Example`
+                    // Instead of matching the whole line, just checking if all values appear in the line should be enough:
+                    let matchLoadAddress = line.contains(binaryImage.loadAddress)
+                    let matchMaxAddress = line.contains(binaryImage.maxAddress)
+                    let matchArchitecture = line.contains(binaryImage.architecture)
+                    let matchLibraryName = line.contains(binaryImage.libraryName)
+                    let matchUUID = line.contains(binaryImage.uuid)
+                    return matchLoadAddress && matchMaxAddress && matchArchitecture && matchLibraryName && matchUUID
+                }
+            )
+        }
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
@@ -119,7 +119,7 @@ extension Date: AnyMockable {
     }
 
     static func mockRandomInThePast() -> Date {
-        return Date(timeIntervalSinceReferenceDate: TimeInterval.random(in: 0..<Date().timeIntervalSinceReferenceDate))
+        return Date(timeIntervalSinceReferenceDate: TimeInterval.mockRandomInThePast())
     }
 
     static func mockSpecificUTCGregorianDate(year: Int, month: Int, day: Int, hour: Int, minute: Int = 0, second: Int = 0) -> Date {
@@ -286,7 +286,7 @@ extension Float: AnyMockable {
 }
 
 extension Double: AnyMockable, RandomMockable {
-    static func mockAny() -> Float {
+    static func mockAny() -> Double {
         return 0
     }
 
@@ -300,11 +300,11 @@ extension Double: AnyMockable, RandomMockable {
 }
 
 extension TimeInterval {
-    static func mockAny() -> TimeInterval {
-        return 0
-    }
-
     static let distantFuture = TimeInterval(integerLiteral: .max)
+
+    static func mockRandomInThePast() -> TimeInterval {
+        return random(in: 0..<Date().timeIntervalSinceReferenceDate)
+    }
 }
 
 struct ErrorMock: Error, CustomStringConvertible {

--- a/Tests/DatadogTests/Datadog/RUM/RUMVitals/VitalInfoSamplerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMVitals/VitalInfoSamplerTests.swift
@@ -24,7 +24,7 @@ class VitalInfoSamplerTests: XCTestCase {
         mockMemoryReader.vitalData = 321.0
         mockRefreshRateReader.vitalInfo = {
             var info = VitalInfo()
-            info.addSample(666.0)
+            info.addSample(60.0)
             return info
         }()
 
@@ -38,8 +38,7 @@ class VitalInfoSamplerTests: XCTestCase {
             XCTAssertGreaterThan(sampler.cpu.sampleCount, 1)
             XCTAssertEqual(sampler.memory.meanValue, 321.0)
             XCTAssertGreaterThan(sampler.memory.sampleCount, 1)
-            let maxFPS = Double(UIScreen.main.maximumFramesPerSecond)
-            XCTAssertEqual(sampler.refreshRate.meanValue, 666.0 / maxFPS)
+            XCTAssertEqual(sampler.refreshRate.meanValue, 60.0)
         }
     }
 

--- a/Tests/DatadogTests/Datadog/Tracing/DDNoopTracerTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/DDNoopTracerTests.swift
@@ -31,7 +31,7 @@ class DDNoopTracerTests: XCTestCase {
         let expectedWarningMessage = """
         The `Global.sharedTracer` was called but no `Tracer` is registered. Configure and register the `Tracer` globally before invoking the feature:
             Global.sharedTracer = Tracer.initialize()
-        See https://docs.datadoghq.com/tracing/setup/ios
+        See https://docs.datadoghq.com/tracing/setup_overview/setup/ios
         """
 
         XCTAssertEqual(output.allRecordedLogs.count, 4)

--- a/docs/rum_collection/advanced_configuration.md
+++ b/docs/rum_collection/advanced_configuration.md
@@ -65,10 +65,10 @@ Example:
 ```swift
 // in your `UIViewController`:
 
-@IBAction func didTapDownloadResourceButton(_ sender: Any) {
+@IBAction func didTapDownloadResourceButton(_ sender: UIButton) {
     Global.rum.addUserAction(
         type: .tap,
-        name: (sender as? UIButton).currentTitle ?? "",
+        name: sender.currentTitle ?? "",
     )
 }
 ```
@@ -214,6 +214,7 @@ Inside the `rumView(for:)` implementation, your app should decide if a given `UI
 For instance, you can configure the predicate to use explicit type check for each view controller in your app:
 ```swift
 class YourCustomPredicate: UIKitRUMViewsPredicate {
+
     func rumView(for viewController: UIViewController) -> RUMView? {
         switch viewController {
         case is HomeViewController:     return .init(name: "Home")
@@ -227,12 +228,13 @@ class YourCustomPredicate: UIKitRUMViewsPredicate {
 You can even come up with a more dynamic solution depending on your app's architecture. For example, if your view controllers use `accessibilityLabel` consistently, you can name views by the value of accessibility label:
 ```swift
 class YourCustomPredicate: UIKitRUMViewsPredicate {
+
     func rumView(for viewController: UIViewController) -> RUMView? {
-        if let accessibilityLabel = viewController.accessibilityLabel {
-            return .init(name: accessibilityLabel)
-        } else {
+        guard let accessibilityLabel = viewController.accessibilityLabel else {
             return nil
         }
+
+        return RUMView(name: accessibilityLabel)
     }
 }
 ```

--- a/docs/rum_collection/data_collected.md
+++ b/docs/rum_collection/data_collected.md
@@ -79,7 +79,7 @@ You can enable [tracking user info][2] globally to collect and apply user attrib
 
 | Attribute name | Type   | Description             |
 |----------------|--------|-------------------------|
-| `user.id`      | string | Identifier of the user. |
+| `usr.id`      | string | Identifier of the user. |
 | `usr.name`     | string | Name of the user.       |
 | `usr.email`    | string | Email of the user.      |
 
@@ -152,7 +152,7 @@ RUM action, error, resource and long task events contain information about the a
 
 | Metric                         | Type           | Description                                                                                     |
 |--------------------------------|----------------|-------------------------------------------------------------------------------------------------|
-| `duration`                     | number         | Entire time spent loading the resource.                                                         |
+| `resource.duration`            | number         | Entire time spent loading the resource.                                                         |
 | `resource.size`                | number (bytes) | Resource size.                                                                                  |
 | `resource.connect.duration`    | number (ns)    | Time spent establishing a connection to the server (connectEnd - connectStart)                  |
 | `resource.ssl.duration`        | number (ns)    | Time spent for the TLS handshake.                                                               |


### PR DESCRIPTION
### :pushpin: References
n/a

### :tophat: What is the goal?

In iOS 15.0, calling `NSProcessInfo.isLowPowerModeEnabled` can trigger a notification of `NSProcessInfoPowerStateDidChangeNotification` to any observers _before_ returning. If they in turn call `NSProcessInfo.isLowPowerModeEnabled` a thread deadlock and then crash will occassionally occur.

The current implementation of `MobileDevice.swift` polls this value every time the logs are submitted. That increases the chance of this happening a lot. We want to reduce the risk.

### How is it being implemented?

By changing `MobileDevice.swift` to also subscribe to `NSProcessInfoPowerStateDidChangeNotification` and then cache the result of `NSProcessInfo.isLowPowerModeEnabled` each time it receives a callback.

### How can it be tested?

Unfortunately, it's not possible to directly test for the crash as it seems to occur in only 1/1000 active users currently. Instead, we need to test that logs are still being delivered with the correct `isLowPowerModeEnabled` value.